### PR TITLE
sleeping .5 secs and pulling the client init out of event_handler

### DIFF
--- a/cloudformation/ssm-auth.yaml
+++ b/cloudformation/ssm-auth.yaml
@@ -46,11 +46,12 @@ Resources:
             import json
             import logging
             import os
+            import time
             logger = logging.getLogger()
             logger.setLevel(logging.INFO)
+            client = boto3.client('cloudformation')
+            lclient = boto3.client('lambda')
             def lambda_handler(event, context):
-              client = boto3.client('cloudformation')
-              lclient = boto3.client('lambda')
               response = client.list_stacks(StackStatusFilter=['CREATE_COMPLETE','UPDATE_COMPLETE','UPDATE_ROLLBACK_COMPLETE'])
               logger.info("%s - %s", event, context)
               for entry in response["StackSummaries"]:
@@ -63,6 +64,7 @@ Resources:
                        "stack_name": entry['StackName'],
                        "iamgroup": out.get('OutputValue')
                        }
+                       time.sleep(0.5)
                        logger.info("Updating Stack:\t%s" % entry['StackName'])
                        resp = lclient.invoke(
                        FunctionName=os.environ['UpdateLambdaName'],

--- a/cloudformation/ssm-auth.yaml
+++ b/cloudformation/ssm-auth.yaml
@@ -56,6 +56,7 @@ Resources:
               logger.info("%s - %s", event, context)
               for entry in response["StackSummaries"]:
                 stack = client.describe_stacks(StackName=entry["StackName"])
+                time.sleep(0.5)
                 outputs = stack.get('Stacks')[0].get('Outputs')
                 if outputs is not None and len(outputs) > 0:
                   for out in outputs:
@@ -64,7 +65,6 @@ Resources:
                        "stack_name": entry['StackName'],
                        "iamgroup": out.get('OutputValue')
                        }
-                       time.sleep(0.5)
                        logger.info("Updating Stack:\t%s" % entry['StackName'])
                        resp = lclient.invoke(
                        FunctionName=os.environ['UpdateLambdaName'],


### PR DESCRIPTION
- import time and call time.sleep() between ssmauth-scan calls
- pulled the lambda and cloudformation client inits outside the event handler